### PR TITLE
Modal bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-quasar-components ChangeLog
 
+## 5.1.1 - 2024-08-xx
+
+### Fixed
+- Pass emit value to createEmitExtendable so emit is not undefined.
+
 ## 5.1.0 - 2024-04-12
 
 ### Changed

--- a/components/BrQModal.vue
+++ b/components/BrQModal.vue
@@ -125,7 +125,7 @@ export default {
   },
   emits: ['accept', 'close', 'update:modelValue'],
   setup(props, {emit}) {
-    const emitExtendable = createEmitExtendable();
+    const emitExtendable = createEmitExtendable({emit});
     const open = computed({
       get: () => props.modelValue,
       set: async value => {


### PR DESCRIPTION
#### _Resolves - bug fix for br modal_

---

### What kind of change does this PR introduce?

- Bug fix.

<br/>

### What is the current behavior?

- BrQModal does not open due to an error with `createEmitExtendable`.

<br/>

### What is the new behavior?

- BrQModal functions as expected by passing emit to `createEmitExtendable`.

<br/>

### Does this PR introduce a breaking change?

- No

<br/>

### How has this been tested?

- Locally rendered.

<br/>

### Screenshots: n/a